### PR TITLE
Fix admin instantiation for GORM v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
   DB.AutoMigrate(&User{}, &Product{})
 
   // Initalize
-  Admin := admin.New(&qor.Config{DB: &DB})
+  Admin := admin.New(&qor.Config{DB: DB})
 
   // Create resources from GORM-backend model
   Admin.AddResource(&User{})


### PR DESCRIPTION
According to http://jinzhu.me/gorm/changelog.html: `gorm.Open return type *gorm.DB instead of gorm.DB`.