### PR TITLE
searcher.go: filters and scopes are ignored

### DIFF
--- a/searcher.go
+++ b/searcher.go
@@ -124,6 +124,8 @@ func (s *Searcher) callScopes(context *qor.Context) *qor.Context {
 			}
 		}
 	}
+	
+	context.SetDB(db)
 
 	// call search
 	var keyword string
@@ -136,7 +138,6 @@ func (s *Searcher) callScopes(context *qor.Context) *qor.Context {
 		return context
 	}
 
-	context.SetDB(db)
 	return context
 }
 


### PR DESCRIPTION
This fixes ignoring scopes and filter setting when keyword is set: SearchHandler used original db instance.