### PR TITLE
Allow singleton resources to have separate show and edit pages

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -110,7 +110,18 @@ func (ac *controller) Show(context *Context) {
 }
 
 func (ac *controller) Edit(context *Context) {
-	result, err := context.FindOne()
+	var result interface{}
+	var err error
+
+	if context.Resource.Config.Singleton {
+		result = context.Resource.NewStruct()
+		if err = context.Resource.CallFindMany(result, context.Context); err == gorm.ErrRecordNotFound {
+			context.Execute("new", result)
+			return
+		}
+	} else {
+		result, err = context.FindOne()
+	}
 	context.AddError(err)
 
 	responder.With("html", func() {

--- a/route.go
+++ b/route.go
@@ -140,6 +140,12 @@ func (admin *Admin) registerResourceToRouter(adminController *controller, res *R
 
 		if mode == "update" {
 			if res.Config.Singleton {
+				// Edit
+				router.Get(path.Join(prefix, "edit"), adminController.Edit, RouteConfig{
+					PermissionMode: roles.Update,
+					Resource:       res,
+				})
+
 				// Update
 				router.Put(prefix, adminController.Update, RouteConfig{
 					PermissionMode: roles.Update,


### PR DESCRIPTION
I have a case where my `ShowAttrs` and `EditAttrs` differs (user isn't allowed to edit some attributes of his resource), so this feature is required. I've duplicated the decision to use `FindManyHandler` with Singletones (instead of FindOne), though I don't fully understand why it is do.