### PR TITLE
Fix Meta of type "select_one" not displaying when the action is "show."

### DIFF
--- a/views/metas/form/select_one.tmpl
+++ b/views/metas/form/select_one.tmpl
@@ -4,10 +4,11 @@
 <div class="qor-field">
   <label class="qor-field__label" for="{{.InputId}}">
     {{meta_label .Meta}}
+
   </label>
 
   <div class="qor-field__show">
-    {{if $is_existing_record}}{{.Value}}{{end}}
+	{{.Value}}
   </div>
 
   {{if .Meta.Config.Select2ResultTemplate}}


### PR DESCRIPTION
Example: In the show slideout of the Users resource "Gender" and "Role"
were not being displayed.