### PR TITLE
Json content type header set in json response.

### DIFF
--- a/transformer_json.go
+++ b/transformer_json.go
@@ -30,7 +30,8 @@ func (JSONTransformer) Encode(writer io.Writer, encoder Encoder) error {
 		result["error"] = err.Error()
 		js, _ = json.Marshal(result)
 	}
-
+	context.Writer.Header().Set("Content-Type", "application/json")
+	
 	_, err = writer.Write(js)
 	return err
 }


### PR DESCRIPTION
Content-type is by default text/plain in response headers, even though JSON requested. 