### PR TITLE
admin: show more detail info when can't found template for meta

### DIFF
--- a/func_map.go
+++ b/func_map.go
@@ -357,7 +357,7 @@ func (context *Context) renderMeta(meta *Meta, value interface{}, prefix []strin
 		} else if metaType == "index" {
 			tmpl, err = tmpl.Parse("{{.Value}}")
 		} else {
-			err = fmt.Errorf("haven't found %v template for meta %v", metaType, meta.Name)
+			err = fmt.Errorf("haven't found template \"%v/%v.tmpl\" for meta %q", metaType, meta.Type, meta.Name)
 		}
 	}
 


### PR DESCRIPTION
### Case

If we set meta.Type as empty string, we will get this error message:

```
got error when render form template for Note2(): haven't found form template for meta Note2
```

This PR will make it as:

```
got error when render form template for Note1(): haven't found template "form/.tmpl" for meta "Note1"
```

So we could know what actually template name we are finding.
