### PR TITLE
Fixes issue with generating urls for singletons (`ToParam()`)

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -124,8 +124,9 @@ func (res *Resource) ToParam() string {
 		} else {
 			if res.Config.Singleton == true {
 				res.params = utils.ToParamString(res.Name)
+			} else {
+				res.params = utils.ToParamString(inflection.Plural(res.Name))
 			}
-			res.params = utils.ToParamString(inflection.Plural(res.Name))
 		}
 	}
 	return res.params


### PR DESCRIPTION
Plural value override the single value in case of singleton