### PR TITLE
Fix meta type date

### DIFF
--- a/meta_datetime.go
+++ b/meta_datetime.go
@@ -24,7 +24,6 @@ func (datetimeConfig *DatetimeConfig) ConfigureQorMeta(metaor resource.Metaor) {
 		if meta.Type == "datetime" {
 			datetimeConfig.ShowTime = true
 		}
-		meta.Type = "datetime"
 
 		if datetimeConfig.ShowTime {
 			timeFormat = "2006-01-02 15:04"


### PR DESCRIPTION
"date" meta type is incorrectly changed to "datetime". A "date" field will have a redundant timepicker in a form. An example is attached below.

![image](https://user-images.githubusercontent.com/3864/39115563-a473ca32-4714-11e8-9449-7ec52d67bc7d.png)

