### PR TITLE
fix(readme) config now lies in package qor

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
   DB.AutoMigrate(&User{}, &Product{})
 
   // Initalize
-  Admin := admin.New(&admin.AdminConfig{DB: DB})
+  Admin := admin.New(&qor.Config{DB: DB})
 
   // Allow to use Admin to manage User, Product
   Admin.AddResource(&User{})


### PR DESCRIPTION
In the newest version, I found ```Config``` now is in ```qor```. So we should use ```Admin := admin.New(&qor.Config{DB: DB})```  instead of ```Admin := admin.New(&admin.AdminConfig{DB: DB})```, or an ```undefined: admin.AdminConfig``` error will be thrown when building the package.