### PR TITLE
Fix nil pointer dereference if no assets path specified

### DIFF
--- a/context.go
+++ b/context.go
@@ -220,6 +220,8 @@ func (context *Context) Execute(name string, result interface{}) {
 		} else {
 			utils.ExitWithMsg(err)
 		}
+	} else {
+		utils.ExitWithMsg(err)
 	}
 
 	context.Result = result


### PR DESCRIPTION
Subject is pretty self-explainable. Edge case, but, still - it panics.