### PR TITLE
Update admin.go

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -74,10 +74,6 @@ func New(config interface{}) *Admin {
 
 	admin.SetAssetFS(admin.AssetFS)
 
-	if admin.AdminConfig.DB != nil {
-		admin.AdminConfig.DB.AutoMigrate(&QorAdminSetting{})
-	}
-
 	admin.registerCompositePrimaryKeyCallback()
 	return &admin
 }


### PR DESCRIPTION
We are calling two times AutoMigrate when the Admin is defined

The AutoMigration is previously called here:
https://github.com/qor/admin/blob/master/settings.go#L19

It is called if SettingsStorage is not defined.