### PR TITLE
Add Iris example as requested at: #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ import (
   "net/http"
   "github.com/jinzhu/gorm"
   _ "github.com/mattn/go-sqlite3"
-  "github.com/qor/qor"
   "github.com/qor/admin"
 )
 
@@ -47,7 +46,7 @@ func main() {
   DB, _ := gorm.Open("sqlite3", "demo.db")
   DB.AutoMigrate(&User{}, &Product{})
 
-  // Initalize
+  // Initialize
   Admin := admin.New(&admin.AdminConfig{DB: DB})
 
   // Allow to use Admin to manage User, Product

--- a/_examples/iris/go.mod
+++ b/_examples/iris/go.mod
@@ -1,0 +1,7 @@
+module github.com/responsibility-act/admin/_examples/iris
+
+go 1.13
+
+require (
+	github.com/kataras/iris/v12 v12.1.8
+)

--- a/_examples/iris/main.go
+++ b/_examples/iris/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/jinzhu/gorm"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/qor/admin"
+
+	"github.com/kataras/iris/v12"
+)
+
+// Create a GORM-backend model
+type User struct {
+	gorm.Model
+	Name string
+}
+
+// Create another GORM-backend model
+type Product struct {
+	gorm.Model
+	Name        string
+	Description string
+}
+
+func main() {
+	DB, _ := gorm.Open("sqlite3", "demo.db")
+	DB.AutoMigrate(&User{}, &Product{})
+
+	qorPrefix := "/admin"
+	// Initialize Qor Admin.
+	Admin := admin.New(&admin.AdminConfig{DB: DB})
+
+	// Allow to use Admin to manage User, Product
+	Admin.AddResource(&User{})
+	Admin.AddResource(&Product{})
+	// Create a qor handler and convert it to an iris one with `iris.FromStd`.
+	handler := iris.FromStd(Admin.NewServeMux(qorPrefix))
+
+	// Initialize Iris.
+	app := iris.New()
+	// Mount routes for "/admin" and "/admin/:xxx/..."
+	app.Any(qorPrefix, handler)
+	app.Any(qorPrefix+"/{p:path}", handler)
+
+	// Start the server.
+	// Navigate at: http://localhost:9000/admin.
+	app.Listen(":9000")
+}


### PR DESCRIPTION
The underscore examples (_examples) can be used to create 3rd-party integration examples. Because the `go get` command ignores that folder. Also fixes a small misspell on README.md. @snowlyg 
 
Thanks,
