### PR TITLE
Disable csrf check for jwt client

### DIFF
--- a/route.go
+++ b/route.go
@@ -148,7 +148,7 @@ func (admin *Admin) NewServeMux(prefix string) http.Handler {
 		Name: "csrf_check",
 		Handler: func(context *Context, middleware *Middleware) {
 			request := context.Request
-			if request.Method != "GET" {
+			if request.Method != "GET" && request.Header.Get("Authorization") == "" {
 				if browserUserAgentRegexp.MatchString(request.UserAgent()) {
 					if referrer := request.Referer(); referrer != "" {
 						if r, err := url.Parse(referrer); err == nil {


### PR DESCRIPTION
If client has Authorization header, auth package is not using cookie based validation.

https://github.com/qor/auth/blob/11d4c974507d28e2fd10ff94edcdd00369e069a6/session_storer.go#L43

the same condition applies to the csrf_check middleware.